### PR TITLE
Added getFrameContexts serialization models and initial implementation.

### DIFF
--- a/Playwright.Axe.Test/JsonSerializerOptionsTests.cs
+++ b/Playwright.Axe.Test/JsonSerializerOptionsTests.cs
@@ -21,7 +21,9 @@ namespace Playwright.Axe.Test
         [DynamicData(nameof(GetAxeSerialSelectorDeserializationData), DynamicDataSourceType.Method)]
         public void AxeSerialSelector_WithOptions_DeserializesToExpected(string jsonInput, AxeSerialSelector expectedAxeSerialSelector)
         {
-            AxeSerialSelector actualAxeSerialSelector = JsonSerializer.Deserialize<AxeSerialSelector>(jsonInput, AxeJsonSerializerOptions.Value);
+            AxeSerialSelector? actualAxeSerialSelector = JsonSerializer.Deserialize<AxeSerialSelector>(jsonInput, AxeJsonSerializerOptions.Value);
+
+            Assert.IsNotNull(actualAxeSerialSelector);
             Assert.AreEqual(expectedAxeSerialSelector, actualAxeSerialSelector!);
         }
 
@@ -42,6 +44,16 @@ namespace Playwright.Axe.Test
                 }),
                 "[\"#id1\",\"#id2\"]"
             };
+
+            yield return new object[]
+{
+                new AxeSerialSelector(new List<AxeCrossTreeSelector>()
+                {
+                    new AxeCrossTreeSelector(new List<string>() { "#frame1", "a" }),
+                    new AxeCrossTreeSelector(new List<string>() { "#frame2", "#inner-frame2", "span" })
+                }),
+                "[[\"#frame1\",\"a\"],[\"#frame2\",\"#inner-frame2\",\"span\"]]"
+            };
         }
 
         private static IEnumerable<object[]> GetAxeSerialSelectorDeserializationData()
@@ -59,6 +71,16 @@ namespace Playwright.Axe.Test
                 {
                     new AxeCrossTreeSelector("#id1"),
                     new AxeCrossTreeSelector("#id2")
+                })
+            };
+
+            yield return new object[]
+            {
+                "[[\"#frame1\",\"a\"],[\"#frame2\",\"#inner-frame2\",\"span\"]]",
+                new AxeSerialSelector(new List<AxeCrossTreeSelector>()
+                {
+                    new AxeCrossTreeSelector(new List<string>() { "#frame1", "a" }),
+                    new AxeCrossTreeSelector(new List<string>() { "#frame2", "#inner-frame2", "span" })
                 })
             };
         }

--- a/Playwright.Axe.Test/JsonSerializerOptionsTests.cs
+++ b/Playwright.Axe.Test/JsonSerializerOptionsTests.cs
@@ -1,0 +1,66 @@
+﻿#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Playwright.Axe.Test
+{
+    [TestClass]
+    public class JsonSerializerOptionsTests
+    {
+        [TestMethod]
+        [DynamicData(nameof(GetAxeSerialSelectorSerializationData), DynamicDataSourceType.Method)]
+        public void AxeSerialSelector_WithOptions_SerializesToExpected(AxeSerialSelector axeSerialSelector, string expectedJson)
+        {
+            string actualJson = JsonSerializer.Serialize(axeSerialSelector, AxeJsonSerializerOptions.Value);
+            Assert.AreEqual(expectedJson, actualJson);
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(GetAxeSerialSelectorDeserializationData), DynamicDataSourceType.Method)]
+        public void AxeSerialSelector_WithOptions_DeserializesToExpected(string jsonInput, AxeSerialSelector expectedAxeSerialSelector)
+        {
+            AxeSerialSelector actualAxeSerialSelector = JsonSerializer.Deserialize<AxeSerialSelector>(jsonInput, AxeJsonSerializerOptions.Value);
+            Assert.AreEqual(expectedAxeSerialSelector, actualAxeSerialSelector!);
+        }
+
+        private static IEnumerable<object[]> GetAxeSerialSelectorSerializationData()
+        {
+            yield return new object[]
+            {
+                new AxeSerialSelector(new AxeCrossTreeSelector("#id")),
+                "\"#id\""
+            };
+
+            yield return new object[]
+            {
+                new AxeSerialSelector(new List<AxeCrossTreeSelector>() 
+                { 
+                    new AxeCrossTreeSelector("#id1"), 
+                    new AxeCrossTreeSelector("#id2") 
+                }),
+                "[\"#id1\",\"#id2\"]"
+            };
+        }
+
+        private static IEnumerable<object[]> GetAxeSerialSelectorDeserializationData()
+        {
+            yield return new object[]
+            {
+                "\"#id\"",
+                new AxeSerialSelector(new AxeCrossTreeSelector("#id"))
+            };
+
+            yield return new object[]
+            {
+                "[\"#id1\",\"#id2\"]",
+                new AxeSerialSelector(new List<AxeCrossTreeSelector>()
+                {
+                    new AxeCrossTreeSelector("#id1"),
+                    new AxeCrossTreeSelector("#id2")
+                })
+            };
+        }
+    }
+}

--- a/Playwright.Axe/AxeCoreWrapper/IAxeCoreWrapper.cs
+++ b/Playwright.Axe/AxeCoreWrapper/IAxeCoreWrapper.cs
@@ -29,6 +29,6 @@ namespace Playwright.Axe.AxeCoreWrapper
         /// <summary>
         /// Gets the frames for a particular run context and determines what context object to use in that frame.
         /// </summary>
-        public Task<IList<AxeFrameContext>> GetFrameContexts(IPage page, AxeRunContext? context = null, AxeRunOptions? options = null);
+        public Task<IList<AxeFrameContext>> GetFrameContexts(IPage page, AxeSerialContext? context = null, AxeRunOptions? options = null);
     }
 }

--- a/Playwright.Axe/AxeCoreWrapper/IAxeCoreWrapper.cs
+++ b/Playwright.Axe/AxeCoreWrapper/IAxeCoreWrapper.cs
@@ -25,5 +25,10 @@ namespace Playwright.Axe.AxeCoreWrapper
         /// Runs Axe on a Playwright Locator
         /// </summary>
         public Task<AxeResults> RunOnLocator(ILocator locator, AxeRunOptions? options = null);
+
+        /// <summary>
+        /// Gets the frames for a particular run context and determines what context object to use in that frame.
+        /// </summary>
+        public Task<IList<AxeFrameContext>> GetFrameContexts(IPage page, AxeRunContext? context = null, AxeRunOptions? options = null);
     }
 }

--- a/Playwright.Axe/AxeCrossTreeSelector.cs
+++ b/Playwright.Axe/AxeCrossTreeSelector.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Playwright.Axe
+{
+    /// <summary>
+    /// Axe Cross Tree Selector
+    /// </summary>
+    public sealed class AxeCrossTreeSelector
+    {
+        /// <summary>
+        /// String Value Selector
+        /// </summary>
+        public string? StringValue { get; }
+
+        /// <summary>
+        /// Array Value Selector
+        /// </summary>
+        public IList<string>? ArrayValue { get; }
+
+        /// <summary>
+        /// Constructor which expects a string.
+        /// </summary>
+        public AxeCrossTreeSelector(string stringValue)
+        {
+            StringValue = stringValue;
+        }
+
+        /// <summary>
+        /// Constructor which expects an Array
+        /// </summary>
+        public AxeCrossTreeSelector(IList<string> arrayValue)
+        {
+            ArrayValue = arrayValue;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object other)
+        {
+            if (other == null)
+                return false;
+
+            if (other is AxeCrossTreeSelector axeSerialSelector)
+            {
+                if(string.Equals(StringValue, axeSerialSelector.StringValue))
+                    return true;
+
+                if(ArrayValue == null && axeSerialSelector.ArrayValue == null)
+                {
+                    return true;
+                }
+
+                if (ArrayValue == null || axeSerialSelector.ArrayValue == null)
+                {
+                    return false;
+                }
+
+                return Enumerable.SequenceEqual(ArrayValue, axeSerialSelector.ArrayValue);
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            if (StringValue != null)
+                return StringValue.GetHashCode();
+            else
+                return ArrayValue!.GetHashCode();
+        }
+    }
+}

--- a/Playwright.Axe/AxeFrameContext.cs
+++ b/Playwright.Axe/AxeFrameContext.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+
+namespace Playwright.Axe
+{
+    /// <summary>
+    /// Run Context for a Frame
+    /// </summary>
+    public sealed class AxeFrameContext
+    {
+        /// <summary>
+        /// Selector for the Frame in question.
+        /// </summary>
+        public AxeCrossTreeSelector FrameSelector { get; }
+
+        /// <summary>
+        /// Run Context for the Frame.
+        /// </summary>
+        public AxeSerialContext FrameContext { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public AxeFrameContext(
+            AxeCrossTreeSelector frameSelector,
+            AxeSerialContext frameContext)
+        {
+            FrameSelector = frameSelector;
+            FrameContext = frameContext;
+        }
+    }
+}

--- a/Playwright.Axe/AxeJsonSerializerOptions.cs
+++ b/Playwright.Axe/AxeJsonSerializerOptions.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Playwright.Axe
+{
+    /// <summary>
+    /// Json Options for Serializing and Deserializing Axe Models
+    /// </summary>
+    public static class AxeJsonSerializerOptions
+    {
+        /// <summary>
+        /// Value
+        /// </summary>
+        public static readonly JsonSerializerOptions Value = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
+                new RunContextJsonConverter(),
+                new CrossTreeSelectorJsonConverter(),
+                new SerialSelectorJsonConverter()
+            },
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            ReferenceHandler = ReferenceHandler.IgnoreCycles
+        };
+    }
+}

--- a/Playwright.Axe/AxeSerialContext.cs
+++ b/Playwright.Axe/AxeSerialContext.cs
@@ -1,0 +1,29 @@
+﻿#nullable enable
+
+namespace Playwright.Axe
+{
+    /// <summary>
+    /// Serialized Run Context
+    /// </summary>
+    public sealed class AxeSerialContext
+    {
+        /// <summary>
+        /// Selector which specifies what to include.
+        /// </summary>
+        public AxeSerialSelector? Include { get; }
+
+        /// <summary>
+        /// Selector which specifies what to exclude.
+        /// </summary>
+        public AxeSerialSelector? Exclude { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public AxeSerialContext(AxeSerialSelector? include, AxeSerialSelector? exclude)
+        {
+            Include = include;
+            Exclude = exclude;
+        }
+    }
+}

--- a/Playwright.Axe/AxeSerialSelector.cs
+++ b/Playwright.Axe/AxeSerialSelector.cs
@@ -1,0 +1,87 @@
+﻿#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Playwright.Axe
+{
+    /// <summary>
+    /// Axe Serial Selector
+    /// </summary>
+    public sealed class AxeSerialSelector
+    {
+        /// <summary>
+        /// Single Value Selector
+        /// </summary>
+        public AxeCrossTreeSelector? Single { get; }
+
+        /// <summary>
+        /// Array Value Selector
+        /// </summary>
+        public IList<AxeCrossTreeSelector>? Array { get; }
+
+        /// <summary>
+        /// Single Value Constructor
+        /// </summary>
+        public AxeSerialSelector(AxeCrossTreeSelector single)
+        {
+            Single = single;
+        }
+
+        /// <summary>
+        /// Array Value Constructor
+        /// </summary>
+        public AxeSerialSelector(IList<AxeCrossTreeSelector> array)
+        {
+            Array = array;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object other)
+        {
+            if (other == null)
+                return false;
+
+            if (other is AxeSerialSelector axeSerialSelector)
+            {
+                if (Single == null && axeSerialSelector.Single == null)
+                {
+                    return true;
+                }
+
+                if (Single == null || axeSerialSelector.Single == null)
+                {
+                    return false;
+                }
+
+                if(Single.Equals(axeSerialSelector.Single))
+                {
+                    return true;
+                }
+
+                if (Array == null && axeSerialSelector.Array == null)
+                {
+                    return true;
+                }
+
+                if (Array == null || axeSerialSelector.Array == null)
+                {
+                    return false;
+                }
+
+                return Enumerable.SequenceEqual(Array, axeSerialSelector.Array);
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            if(Single != null)
+                return Single.GetHashCode();
+            else
+                return Array!.GetHashCode();
+        }
+    }
+}

--- a/Playwright.Axe/CrossTreeSelectorJsonConverter.cs
+++ b/Playwright.Axe/CrossTreeSelectorJsonConverter.cs
@@ -1,0 +1,71 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Playwright.Axe
+{
+    /// <summary>
+    /// Converter for Cross Tree Selector
+    /// </summary>
+    public sealed class CrossTreeSelectorJsonConverter : JsonConverter<AxeCrossTreeSelector>
+    {
+        /// <inheritdoc/>
+        public override AxeCrossTreeSelector? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if(reader.TokenType == JsonTokenType.StartArray)
+            {
+                reader.Read();
+
+                IList<string> elements = new List<string>();
+
+                while (reader.TokenType != JsonTokenType.EndArray)
+                {
+                    string? arrVal = reader.GetString();
+
+                    if(arrVal == null)
+                    {
+                        throw new JsonException("Unexpected value in selector array.");
+                    }
+
+                    elements.Add(arrVal);
+
+                    reader.Read();
+                }
+
+                return new AxeCrossTreeSelector(elements);
+            }
+
+            string? str = reader.GetString();
+
+            if(str != null)
+            {
+                return new AxeCrossTreeSelector(str);
+            }
+
+            throw new JsonException("Unexpected selector value.");
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, AxeCrossTreeSelector value, JsonSerializerOptions options)
+        {
+            if(value.StringValue != null)
+            {
+                writer.WriteStringValue(value.StringValue);
+            } 
+            else
+            {
+                writer.WriteStartArray();
+
+                foreach(string str in value.ArrayValue!)
+                {
+                    writer.WriteStringValue(str);
+                }
+
+                writer.WriteEndArray();
+            }
+        }
+    }
+}

--- a/Playwright.Axe/SerialSelectorJsonConverter.cs
+++ b/Playwright.Axe/SerialSelectorJsonConverter.cs
@@ -51,6 +51,8 @@ namespace Playwright.Axe
                                 
                             reader.Read();
                         }
+
+                        crossTreeSelectors.Add(new AxeCrossTreeSelector(innerTreeSelectors));
                     }
                     else if (reader.TokenType == JsonTokenType.String)
                     {

--- a/Playwright.Axe/SerialSelectorJsonConverter.cs
+++ b/Playwright.Axe/SerialSelectorJsonConverter.cs
@@ -1,0 +1,82 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Playwright.Axe
+{
+    /// <summary>
+    /// Json Converter for Frame Selector
+    /// </summary>
+    public sealed class SerialSelectorJsonConverter : JsonConverter<AxeSerialSelector>
+    {
+        /// <inheritdoc/>
+        public override AxeSerialSelector? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            // Selector is either a string
+            if(reader.TokenType == JsonTokenType.String)
+            {
+                string stringSelector = reader.GetString()!;
+                return new AxeSerialSelector(new AxeCrossTreeSelector(stringSelector));
+            }
+
+            // Selector is an array
+            if(reader.TokenType == JsonTokenType.StartArray)
+            {
+                reader.Read();
+
+                IList<AxeCrossTreeSelector> crossTreeSelectors = new List<AxeCrossTreeSelector>();
+
+                while(reader.TokenType != JsonTokenType.EndArray)
+                {
+                    IList<string> innerTreeSelectors = new List<string>();
+
+                    // Selector is an array of arrays
+                    if (reader.TokenType == JsonTokenType.StartArray)
+                    {
+                        reader.Read();
+
+                        while (reader.TokenType != JsonTokenType.EndArray)
+                        {
+                            if (reader.TokenType == JsonTokenType.String)
+                            {
+                                innerTreeSelectors.Add(reader.GetString()!);
+                            } 
+                            else
+                            {
+                                throw new JsonException();
+                            }
+                                
+                            reader.Read();
+                        }
+                    }
+                    else if (reader.TokenType == JsonTokenType.String)
+                    {
+                        crossTreeSelectors.Add(new AxeCrossTreeSelector(reader.GetString()!));
+                    }
+
+                    reader.Read();
+                }
+                
+                return new AxeSerialSelector(crossTreeSelectors);
+            }
+
+            throw new JsonException("Unexpected selector value.");
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, AxeSerialSelector value, JsonSerializerOptions options)
+        {
+            if(value.Single != null)
+            {
+                writer.WriteRawValue(JsonSerializer.Serialize(value.Single, options));
+            } 
+            else
+            {
+                writer.WriteRawValue(JsonSerializer.Serialize(value.Array, options));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added getFrameContexts serialization models and initial implementation.


This is to support the implementation of RunPartial, which will need the frame contexts returned to the Playwright context before calling runPartial on each frame:
![image](https://user-images.githubusercontent.com/36536997/184685407-b1f52782-5af3-445c-85bc-bbfbb4f3d3da.png)
